### PR TITLE
Adding R Gate

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,5 +8,5 @@ jinja2==3.1.4
 twine==4.0.2
 pytest==7.4.4
 black==24.3.0
-pyqir==0.10.0
+iqm-pyqir==0.11.0
 qiskit>=1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
 	qiskit>=1.0.0,<2.0
-	pyqir>=0.10.0,<0.11.0
+	iqm-pyqir==0.11.0
 
 [options.extras_require]
 test = pytest

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -75,6 +75,7 @@ _QUANTUM_INSTRUCTIONS = [
     "m",
     "measure",
     "reset",
+    "r",
     "rx",
     "ry",
     "rz",
@@ -88,7 +89,7 @@ _QUANTUM_INSTRUCTIONS = [
     "z",
 ]
 
-_NOOP_INSTRUCTIONS = ["delay", "r"]
+_NOOP_INSTRUCTIONS = ["delay"]
 
 _SUPPORTED_INSTRUCTIONS = _QUANTUM_INSTRUCTIONS + _NOOP_INSTRUCTIONS
 

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -88,7 +88,7 @@ _QUANTUM_INSTRUCTIONS = [
     "z",
 ]
 
-_NOOP_INSTRUCTIONS = ["delay"]
+_NOOP_INSTRUCTIONS = ["delay", "r"]
 
 _SUPPORTED_INSTRUCTIONS = _QUANTUM_INSTRUCTIONS + _NOOP_INSTRUCTIONS
 
@@ -330,6 +330,8 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                 qis.h(self._builder, *qubits)
             elif "reset" == instruction.name:
                 qis.reset(self._builder, qubits[0])
+            elif "r" == instruction.name:
+                qis.r(self._builder, *instruction.params, *qubits)
             elif "rx" == instruction.name:
                 qis.rx(self._builder, *instruction.params, *qubits)
             elif "ry" == instruction.name:

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -74,8 +74,8 @@ _QUANTUM_INSTRUCTIONS = [
     "id",
     "m",
     "measure",
-    "reset",
     "r",
+    "reset",
     "rx",
     "ry",
     "rz",
@@ -329,10 +329,10 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                 qis.cz(self._builder, *qubits)
             elif "h" == instruction.name:
                 qis.h(self._builder, *qubits)
-            elif "reset" == instruction.name:
-                qis.reset(self._builder, qubits[0])
             elif "r" == instruction.name:
                 qis.r(self._builder, *instruction.params, *qubits)
+            elif "reset" == instruction.name:
+                qis.reset(self._builder, qubits[0])
             elif "rx" == instruction.name:
                 qis.rx(self._builder, *instruction.params, *qubits)
             elif "ry" == instruction.name:

--- a/tests/test_circuits/basic_gates.py
+++ b/tests/test_circuits/basic_gates.py
@@ -99,7 +99,7 @@ def _generate_r_fixture(gate: str):
         circuit = QuantumCircuit(1)
         getattr(circuit, gate)(0.5, 0.5, 0)
         return _map_gate_name(gate), circuit
-    return test_fixture()
+    return test_fixture
 
 name = _fixture_name(general_r_gate["r"])
 locals()[name] = _generate_r_fixture(name)

--- a/tests/test_circuits/basic_gates.py
+++ b/tests/test_circuits/basic_gates.py
@@ -27,7 +27,7 @@ _measurements = {"measure": "mz"}
 
 _rotations = {"rx": "rx", "ry": "ry", "rz": "rz"}
 
-general_r_gate = {"r": "r"}
+_general_r_gate = {"r": "r"}
 
 _two_qubit_gates = {"cx": "cnot", "cz": "cz", "swap": "swap"}
 
@@ -47,6 +47,8 @@ def _map_gate_name(gate: str) -> str:
         return _measurements[gate]
     elif gate in _rotations:
         return _rotations[gate]
+    elif gate in _general_r_gate:
+        return _general_r_gate[gate]
     elif gate in _two_qubit_gates:
         return _two_qubit_gates[gate]
     elif gate in _three_qubit_gates:
@@ -101,8 +103,9 @@ def _generate_r_fixture(gate: str):
         return _map_gate_name(gate), circuit
     return test_fixture
 
-name = _fixture_name(general_r_gate["r"])
-locals()[name] = _generate_r_fixture(name)
+for gate in _general_r_gate.keys():
+    name = _fixture_name(gate)
+    locals()[name] = _generate_r_fixture(gate)
 
 
 def _generate_two_qubit_fixture(gate: str):
@@ -155,7 +158,7 @@ for gate in _measurements.keys():
 single_op_tests = [_fixture_name(s) for s in _one_qubit_gates.keys()]
 adj_op_tests = [_fixture_name(s) for s in _adj_gates.keys()]
 rotation_tests = [_fixture_name(s) for s in _rotations.keys()]
-r_test = [_fixture_name(general_r_gate["r"])]
+r_test = [_fixture_name(_general_r_gate["r"])]
 double_op_tests = [_fixture_name(s) for s in _two_qubit_gates.keys()]
 triple_op_tests = [_fixture_name(s) for s in _three_qubit_gates.keys()]
 measurement_tests = [_fixture_name(s) for s in _measurements.keys()]

--- a/tests/test_circuits/basic_gates.py
+++ b/tests/test_circuits/basic_gates.py
@@ -27,6 +27,8 @@ _measurements = {"measure": "mz"}
 
 _rotations = {"rx": "rx", "ry": "ry", "rz": "rz"}
 
+general_r_gate = {"r": "r"}
+
 _two_qubit_gates = {"cx": "cnot", "cz": "cz", "swap": "swap"}
 
 _three_qubit_gates = {"ccx": "ccx"}
@@ -91,6 +93,17 @@ for gate in _rotations.keys():
     name = _fixture_name(gate)
     locals()[name] = _generate_rotation_fixture(gate)
 
+def _generate_r_fixture(gate: str):
+    @pytest.fixture()
+    def test_fixture():
+        circuit = QuantumCircuit(1)
+        getattr(circuit, gate)(0.5, 0.5, 0)
+        return _map_gate_name(gate), circuit
+    return test_fixture()
+
+name = _fixture_name(general_r_gate["r"])
+locals()[name] = _generate_r_fixture(name)
+
 
 def _generate_two_qubit_fixture(gate: str):
     @pytest.fixture()
@@ -142,6 +155,7 @@ for gate in _measurements.keys():
 single_op_tests = [_fixture_name(s) for s in _one_qubit_gates.keys()]
 adj_op_tests = [_fixture_name(s) for s in _adj_gates.keys()]
 rotation_tests = [_fixture_name(s) for s in _rotations.keys()]
+r_test = [_fixture_name(general_r_gate["r"])]
 double_op_tests = [_fixture_name(s) for s in _two_qubit_gates.keys()]
 triple_op_tests = [_fixture_name(s) for s in _three_qubit_gates.keys()]
 measurement_tests = [_fixture_name(s) for s in _measurements.keys()]

--- a/tests/test_qiskit_qir.py
+++ b/tests/test_qiskit_qir.py
@@ -17,6 +17,7 @@ from test_circuits.basic_gates import (
     single_op_tests,
     adj_op_tests,
     rotation_tests,
+    r_test,
     double_op_tests,
     triple_op_tests,
     measurement_tests,
@@ -116,6 +117,17 @@ def test_rotation_gates(circuit_name, request):
     func = test_utils.get_entry_point_body(generated_qir)
     assert func[0] == test_utils.initialize_call_string()
     assert func[1] == test_utils.rotation_call_string(qir_op, 0.5, 0)
+    assert func[2] == test_utils.return_string()
+    assert len(func) == 3
+
+@pytest.mark.parametrize("circuit_name", r_test)
+def test_r_gate(circuit_name, request):
+    qir_op, circuit = request.getfixturevalue(circuit_name)
+    generated_qir = str(to_qir_module(circuit)[0]).splitlines()
+    test_utils.check_attributes(generated_qir, 1, 0)
+    func = test_utils.get_entry_point_body(generated_qir)
+    assert func[0] == test_utils.initialize_call_string()
+    assert func[1] == test_utils.multiparameter_rotation_call_string(qir_op, 0.5, 0.5, 0)
     assert func[2] == test_utils.return_string()
     assert len(func) == 3
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,9 @@ def double_op_call_string(name: str, qb1: int, qb2: int) -> str:
 def rotation_call_string(name: str, theta: float, qb: int) -> str:
     return f"call void @__quantum__qis__{name}__body(double {theta:#e}, {_qubit_string(qb)})"
 
+def multiparameter_rotation_call_string(name: str, theta: float, phi: float, qb: int) -> str:
+    return f"call void @__quantum__qis__{name}__body(double {theta:#e}, double {phi:#e}, {_qubit_string(qb)})"
+
 
 def measure_call_string(name: str, res: str, qb: int) -> str:
     return f"call void @__quantum__qis__{name}__body({_qubit_string(qb)}, {_result_string(res)})"


### PR DESCRIPTION
The Qiskit[RGate](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.RGate) is one of the native gates of IQM's superconducting device, and in order to use qiskit_qir to translate transpiled Qiskit circuits to QIR supported by IQM software, RGate support needs to be implemented in qiskit_qir and pyqir. 

Related to this [PR](https://github.com/iqm-finland/pyqir/pull/1) in pyqir